### PR TITLE
Update "CodePotent" to "Code Potent"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 * FIX: Fix for PHP error when refreshing sitemap in Search Console
 
 #### v 1.0.0-beta1 / 2020-02-08
-* NEW: Integrated CodePotent's Update Manager
+* NEW: Integrated Code Potent's Update Manager
 * NEW: Check for WP_CLI (props xxsimoxx)
 * IMPROVED: Services rich snippets (added missing properties)
 * Moved to new ClassicPress-plugins GitHub repository

--- a/includes/class-update-client.php
+++ b/includes/class-update-client.php
@@ -11,7 +11,7 @@
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Full
  * text of the license is available at https://www.gnu.org/licenses/gpl-2.0.txt.
  * -----------------------------------------------------------------------------
- * Copyright © 2019 - CodePotent
+ * Copyright © 2020, Code Potent
  */
 
 // EDIT: Make this unique. Example: YourDevName\YourPluginName;
@@ -130,7 +130,7 @@ class UpdateClient {
 
 		// Print footer scripts; see comments on the method.
 		add_action('admin_print_footer_scripts', [$this, 'print_admin_scripts']);
-		
+
 		// Filter the plugin admin row.
 		add_filter('plugin_row_meta', [$this, 'filter_plugin_row_meta'], 10, 2);
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Classic SEO is the first SEO plugin built specifically to work with ClassicPress
 * FIX: Fix for PHP error when refreshing sitemap in Search Console
 
 **v 1.0.0-beta1 / 2020-02-08**
-* NEW: Integrated CodePotent's Update Manager
+* NEW: Integrated Code Potent's Update Manager
 * NEW: Check for WP_CLI (props xxsimoxx)
 * IMPROVED: Services rich snippets (added missing properties)
 * Moved to new ClassicPress-plugins GitHub repository


### PR DESCRIPTION
# Description
In spite of my best efforts, I've used the term "Code Potent" in a confusing way which has caused others to replicate the error. This pull request brings it correct.

# Context
The term "Code Potent" (my brand and username) is two words, but, there _are_ some places where it is used without a space. Let me clarify...for all of us. :)

- In a namespace, it is `CodePotent` with initial caps and no space.
- In a constant, it is `CODE_POTENT` with all caps and underscore.
- As a brand name, it is `Code Potent` with initial caps and a space; My logo is wrong. :)
- Other (ie, text domains, JS/CSS prefixes, paths,) it is `codepotent` with lowercase, no space, and no hyphen.
