### PR TITLE
Fix for missing cpseo prefix in some settings

### DIFF
--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -198,7 +198,7 @@ class Common {
 		/* translators: this should be an array of stop words for your language, separated by comma's. */
 		$stopwords = explode( ',', esc_html__( "a,about,above,after,again,against,all,am,an,and,any,are,as,at,be,because,been,before,being,below,between,both,but,by,could,did,do,does,doing,down,during,each,few,for,from,further,had,has,have,having,he,he'd,he'll,he's,her,here,here's,hers,herself,him,himself,his,how,how's,i,i'd,i'll,i'm,i've,if,in,into,is,it,it's,its,itself,let's,me,more,most,my,myself,nor,of,on,once,only,or,other,ought,our,ours,ourselves,out,over,own,same,she,she'd,she'll,she's,should,so,some,such,than,that,that's,the,their,theirs,them,themselves,then,there,there's,these,they,they'd,they'll,they're,they've,this,those,through,to,too,under,until,up,very,was,we,we'd,we'll,we're,we've,were,what,what's,when,when's,where,where's,which,while,who,who's,whom,why,why's,with,would,you,you'd,you'll,you're,you've,your,yours,yourself,yourselves", 'cpseo' ) );
 
-		$custom = Helper::get_settings( 'general.stopwords' );
+		$custom = Helper::get_settings( 'general.cpseo_stopwords' );
 		$custom = Str::to_arr_no_empty( $custom );
 
 		return array_unique( array_merge( $stopwords, $custom ) );

--- a/includes/class-installer.php
+++ b/includes/class-installer.php
@@ -129,7 +129,6 @@ class Installer {
 	private function activate() {
 		$current_version		= get_option( 'cpseo_version', null );
 		$current_db_version		= get_option( 'cpseo_db_version', null );
-		$pre_release_version	= get_option( 'cpseo_pre_release_version', null );
 
 		$this->create_tables();
 		$this->create_options();
@@ -143,7 +142,6 @@ class Installer {
 		// Update to latest version.
 		update_option( 'cpseo_version', CPSEO_VERSION );
 		update_option( 'cpseo_db_version', CPSEO_DB_VERSION );
-		update_option( 'cpseo_pre_release_version', CPSEO_PRE_RELEASE_VERSION );
 
 		// Save install date.
 		if ( false === boolval( get_option( 'cpseo_install_date' ) ) ) {

--- a/includes/class-updates.php
+++ b/includes/class-updates.php
@@ -31,12 +31,12 @@ class Updates implements Runner {
 	];
 	
 	/**
-	 * Updates that need to be run
+	 * Pre-release (e.g. beta) pdates that need to be run
 	 *
 	 * @var array
 	 */
 	private static $pre_release_updates = [
-		'1.0.0'   => 'updates/update-1.0.0-beta.4.php',
+		'4'   => 'updates/update-1.0.0-beta.4.php',
 	];
 
 	/**
@@ -51,7 +51,6 @@ class Updates implements Runner {
 	 */
 	public static function do_updates() {
 		$installed_version = get_option( 'cpseo_version' );
-		$pre_release_installed_version = get_option( 'cpseo_pre_release_version' );
 
 		// Maybe it's the first install.
 		if ( ! $installed_version ) {
@@ -61,12 +60,8 @@ class Updates implements Runner {
 		if ( version_compare( $installed_version, cpseo()->version, '<' ) ) {
 			self::perform_updates();
 		}
-		
-		// TODO: What if cpseo_pre_release_version does not exist????
-		
-		if ( version_compare( $pre_release_installed_version, cpseo()->pre_release_version, '<' ) ) {
-			self::perform_pre_release_updates();
-		}
+
+		self::perform_pre_release_updates();
 	}
 
 	/**
@@ -101,7 +96,7 @@ class Updates implements Runner {
 		
 		if ( ! empty(self::$pre_release_updates ) ) {
 			foreach ( self::$pre_release_updates as $pre_release_version => $path ) {
-				if ( version_compare( $pre_release_installed_version, $pre_release_version, '<' ) ) {
+				if ( $pre_release_installed_version < $pre_release_version ) {
 					include $path;
 					update_option( 'cpseo_pre_release_version', $pre_release_version );
 				}
@@ -110,5 +105,4 @@ class Updates implements Runner {
 
 		update_option( 'cpseo_pre_release_version', cpseo()->pre_release_version );
 	}
-
 }

--- a/includes/frontend/class-add-attributes.php
+++ b/includes/frontend/class-add-attributes.php
@@ -187,7 +187,7 @@ class Add_Attributes {
 		}
 
 		$setting = 'include' === $type ? 'cpseo_nofollow_domains' : 'cpseo_nofollow_exclude_domains';
-		$domains = Helper::get_settings( "general.{$setting}" );
+		$domains = Helper::get_settings( "general.cpseo_{$setting}" );
 		$domains = Str::to_arr_no_empty( $domains );
 
 		$cpseo_cpseo_nofollow_domains[ $type ] = empty( $domains ) ? false : join( ';', $domains );

--- a/includes/frontend/class-breadcrumbs.php
+++ b/includes/frontend/class-breadcrumbs.php
@@ -81,7 +81,7 @@ class Breadcrumbs {
 				'remove_title'    => Helper::get_settings( 'general.cpseo_breadcrumbs_remove_post_title' ),
 				'hide_tax_name'   => Helper::get_settings( 'general.cpseo_breadcrumbs_hide_taxonomy_name' ),
 				'show_ancestors'  => Helper::get_settings( 'general.cpseo_breadcrumbs_ancestor_categories' ),
-				'show_blog'       => Helper::get_settings( 'general.breadcrumbs_blog_page' ),
+				'show_blog'       => Helper::get_settings( 'general.cpseo_breadcrumbs_blog_page' ),
 				'show_pagination' => true,
 			]
 		);

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -232,7 +232,7 @@ class Frontend {
 	 * @return string
 	 */
 	private function get_rss_content( $which ) {
-		$content = $this->do_filter( 'frontend/rss/' . $which . '_content', Helper::get_settings( 'general.rss_' . $which . '_content' ) );
+		$content = $this->do_filter( 'frontend/rss/' . $which . '_content', Helper::get_settings( 'general.cpseo_rss_' . $which . '_content' ) );
 
 		return '' !== $content ? wpautop( $this->rss_replace_vars( $content ) ) : $content;
 	}

--- a/includes/frontend/class-shortcodes.php
+++ b/includes/frontend/class-shortcodes.php
@@ -60,7 +60,7 @@ class Shortcodes {
 	 * @return string
 	 */
 	public function breadcrumb( $args ) {
-		if ( ! Helper::get_settings( 'general.breadcrumbs' ) ) {
+		if ( ! Helper::get_settings( 'general.cpseo_breadcrumbs' ) ) {
 			return;
 		}
 		return Breadcrumbs::get()->get_breadcrumb( $args );

--- a/includes/helpers/class-post-type.php
+++ b/includes/helpers/class-post-type.php
@@ -72,7 +72,7 @@ trait Post_Type {
 		static $posts_to_exclude;
 
 		if ( ! isset( $posts_to_exclude ) ) {
-			$posts_to_exclude = wp_parse_id_list( Helper::get_settings( 'sitemap.exclude_posts' ) );
+			$posts_to_exclude = wp_parse_id_list( Helper::get_settings( 'sitemap.cpseo_exclude_posts' ) );
 			$posts_to_exclude = apply_filters( 'cpseo/sitemap/posts_to_exclude', $posts_to_exclude );
 		}
 

--- a/includes/modules/rich-snippet/views/article.php
+++ b/includes/modules/rich-snippet/views/article.php
@@ -21,7 +21,7 @@ $cmb->add_field([
 		'BlogPosting' => esc_html__( 'Blog Post', 'cpseo' ),
 		'NewsArticle' => esc_html__( 'News Article', 'cpseo' ),
 	],
-	'default' => Helper::get_settings( "titles.pt_{$post_type}_default_article_type" ),
+	'default' => Helper::get_settings( "titles.cpseo_pt_{$post_type}_default_article_type" ),
 	'classes' => 'nob',
 	'desc'    => $article_desc,
 	'dep'     => $article_dep,

--- a/includes/modules/rich-snippet/views/job-posting.php
+++ b/includes/modules/rich-snippet/views/job-posting.php
@@ -110,7 +110,7 @@ $cmb->add_field([
 	'name'       => esc_html__( 'Hiring Organization', 'cpseo' ),
 	'desc'       => esc_html__( 'The name of the company. Leave empty to use your own company information.', 'cpseo' ),
 	'attributes' => [
-		'placeholder' => 'company' === Helper::get_settings( 'titles.knowledgegraph_type' ) ? Helper::get_settings( 'titles.cpseo_knowledgegraph_name' ) : get_bloginfo( 'name' ),
+		'placeholder' => 'company' === Helper::get_settings( 'titles.cpseo_knowledgegraph_type' ) ? Helper::get_settings( 'titles.cpseo_knowledgegraph_name' ) : get_bloginfo( 'name' ),
 	],
 	'dep'        => $jobposting,
 	'classes'    => 'cmb-row-50',

--- a/includes/modules/search-console/class-client.php
+++ b/includes/modules/search-console/class-client.php
@@ -257,7 +257,7 @@ class Client {
 	 */
 	private function set_data() {
 		$this->data    = Helper::search_console_data();
-		$this->profile = Helper::get_settings( 'general.console_profile' );
+		$this->profile = Helper::get_settings( 'general.cpseo_console_profile' );
 
 		if ( ! $this->profile && ! empty( $this->data['profiles'] ) ) {
 			$this->profile = key( $this->data['profiles'] );

--- a/includes/modules/search-console/views/options.php
+++ b/includes/modules/search-console/views/options.php
@@ -26,7 +26,7 @@ $cmb->add_field([
 	'after_field' => $primary . $secondary,
 ]);
 
-$profile       = Helper::get_settings( 'general.console_profile' );
+$profile       = Helper::get_settings( 'general.cpseo_console_profile' );
 $profile_label = str_replace( 'sc-domain:', __( 'Domain Property: ', 'cpseo' ), $profile );
 foreach ( $data['profiles'] as $key => $value ) {
 	$data['profiles'][ $key ] = str_replace( 'sc-domain:', __( 'Domain Property: ', 'cpseo' ), $value );
@@ -36,7 +36,7 @@ if ( ! $data['authorized'] ) {
 }
 
 $cmb->add_field([
-	'id'          => 'console_profile',
+	'id'          => 'cpseo_console_profile',
 	'type'        => 'select',
 	'name'        => esc_html__( 'Search Console Profile', 'cpseo' ),
 	'desc'        => esc_html__( 'After authenticating with Google Search Console, select the site from the dropdown list.', 'cpseo' ) .

--- a/includes/modules/sitemap/class-admin.php
+++ b/includes/modules/sitemap/class-admin.php
@@ -250,7 +250,7 @@ class Admin extends Base {
 	public function show_on( $field ) {
 
 		$news_sitemap_enabled = Helper::is_module_active( 'news-sitemap' );
-		$is_post_type_news    = in_array( get_post_type(), (array) Helper::get_settings( 'sitemap.news_sitemap_post_type' ), true );
+		$is_post_type_news    = in_array( get_post_type(), (array) Helper::get_settings( 'sitemap.cpseo_news_sitemap_post_type' ), true );
 
 		if ( $news_sitemap_enabled && $is_post_type_news ) {
 			return true;

--- a/includes/modules/sitemap/class-image-parser.php
+++ b/includes/modules/sitemap/class-image-parser.php
@@ -154,7 +154,7 @@ class Image_Parser {
 	private function get_post_thumbnail() {
 		$thumbnail_id = get_post_thumbnail_id( $this->post->ID );
 		if (
-			! Helper::get_settings( 'sitemap.include_featured_image' ) ||
+			! Helper::get_settings( 'sitemap.cpseo_include_featured_image' ) ||
 			! Helper::attachment_in_sitemap( $thumbnail_id )
 		) {
 			return;
@@ -214,7 +214,7 @@ class Image_Parser {
 	 * Get images from custom fields
 	 */
 	private function get_custom_field_images() {
-		$customs = Helper::get_settings( 'sitemap.pt_' . $this->post->post_type . '_image_customfields' );
+		$customs = Helper::get_settings( 'sitemap.cpseo_pt_' . $this->post->post_type . '_image_customfields' );
 		if ( empty( $customs ) ) {
 			return;
 		}

--- a/includes/modules/sitemap/class-sitemap.php
+++ b/includes/modules/sitemap/class-sitemap.php
@@ -171,7 +171,7 @@ class Sitemap {
 	 * @return bool
 	 */
 	public static function can_ping() {
-		if ( false === Helper::get_settings( 'sitemap.ping_search_engines' ) ) {
+		if ( false === Helper::get_settings( 'sitemap.cpseo_ping_search_engines' ) ) {
 			return false;
 		}
 
@@ -184,15 +184,15 @@ class Sitemap {
 	}
 
 	/**
-	 * Exclude object frmofrom sitemap.
+	 * Exclude object from sitemap.
 	 *
 	 * @param  int     $object_id   Object id.
-	 * @param  string  $object_type Object type. Accetps: post, term, user.
+	 * @param  string  $object_type Object type. Accepts: post, term, user.
 	 * @param  boolean $include     Add or Remove object.
 	 */
 	public static function exclude_object( $object_id, $object_type, $include ) {
 		$field_id = "exclude_{$object_type}s";
-		$ids      = Helper::get_settings( 'sitemap.' . $field_id );
+		$ids      = Helper::get_settings( 'sitemap.cpseo_' . $field_id );
 
 		if ( empty( $ids ) ) {
 			$ids = $object_id;

--- a/includes/modules/sitemap/providers/class-taxonomy.php
+++ b/includes/modules/sitemap/providers/class-taxonomy.php
@@ -230,7 +230,7 @@ class Taxonomy implements Provider {
 			'hide_empty' => $hide_empty,
 			'offset'     => $offset,
 			'number'     => $max_entries,
-			'exclude'    => wp_parse_id_list( Helper::get_settings( 'sitemap.exclude_terms' ) ),
+			'exclude'    => wp_parse_id_list( Helper::get_settings( 'sitemap.cpseo_exclude_terms' ) ),
 		]);
 		$this->remove_filter( 'get_terms_fields', 'filter_terms_query', 20 );
 

--- a/includes/modules/sitemap/sitemap-xsl.php
+++ b/includes/modules/sitemap/sitemap-xsl.php
@@ -285,7 +285,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 									<thead>
 										<tr>
 											<th width="80%"><?php esc_html_e( 'URL', 'cpseo' ); ?></th>
-											<?php if ( Helper::get_settings( 'sitemap.include_images' ) ) : // phpcs:ignore ?><th width="5%"><?php esc_html_e( 'Images', 'cpseo' ); ?></th><?php endif; ?>
+											<?php if ( Helper::get_settings( 'sitemap.cpseo_include_images' ) ) : // phpcs:ignore ?><th width="5%"><?php esc_html_e( 'Images', 'cpseo' ); ?></th><?php endif; ?>
 											<th title="Last Modification Time" width="15%"><?php esc_html_e( 'Last Mod.', 'cpseo' ); ?></th>
 										</tr>
 									</thead>
@@ -303,7 +303,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 														<xsl:value-of select="sitemap:loc"/>
 													</a>
 												</td>
-												<?php if ( Helper::get_settings( 'sitemap.include_images' ) ) : ?>
+												<?php if ( Helper::get_settings( 'sitemap.cpseo_include_images' ) ) : ?>
 												<td>
 													<xsl:value-of select="count(image:image)"/>
 												</td>

--- a/includes/updates/update-1.0.0-beta.4.php
+++ b/includes/updates/update-1.0.0-beta.4.php
@@ -12,6 +12,7 @@ use Classic_SEO\Helper;
 use Classic_SEO\Admin\Admin_Helper;
 
 
+
 /**
  * Convert old snippet variables to new one
  */
@@ -36,4 +37,76 @@ function cpseo_1_0_0_beta_4_convert_snippet_variables() {
 	Helper::update_all_settings( null, $titles, null );
 	cpseo()->settings->reset();
 }
+
+
+/*
+ * GitHub issue #80
+ * https://github.com/ClassicPress-plugins/classicpress-seo/issues/80
+ * Fixes missing "cpseo_" prefix in some settings
+ */
+function cpseo_1_0_0_beta_4_add_settings_prefix() {
+	$prefix				= 'cpseo_';
+	$all_opts			= cpseo()->settings->all_raw();
+	$general_options	= $all_opts['general'];
+	$titles_options		= $all_opts['titles'];
+	$sitemap_options	= $all_opts['sitemap'];
+
+	$general_includes = [
+		'stopwords',
+		'breadcrumbs_blog_page',
+		'rss_before_content',
+		'rss_after_content',
+		'breadcrumbs',
+		'console_profile',
+	];
+
+	$titles_includes = [
+		'pt_post_default_article_type',
+		'pt_page_default_article_type',
+		'pt_attachment_default_article_type',
+		'pt_product_default_article_type',
+		'knowledgegraph_type',
+	];
+
+	$sitemap_includes = [
+		'news_sitemap_post_type',
+		'include_featured_image',
+		'ping_search_engines',
+		'exclude_posts',
+		'exclude_terms',
+		'include_images',
+	];
+
+	foreach ( $general_includes as $general ) {
+		$gen_opt = Helper::get_settings( "general.{$general}" );
+		if ( $gen_opt ) {
+			$general_options[ "{$prefix}{$general}" ] = $gen_opt;
+		}
+	}
+	if ( $general_options ) {
+		Helper::update_all_settings( $general_options, null, null );
+	}
+
+	foreach ( $titles_includes as $titles ) {
+		$title_opt = Helper::get_settings( "titles.{$titles}" );
+		if ( $title_opt ) {
+			$titles_options[ "{$prefix}{$titles}" ] = $title_opt;
+		}
+	}
+	if ( $titles_options ) {
+		Helper::update_all_settings( null, $titles_options, null );
+	}
+
+	foreach ( $sitemap_includes as $sitemap ) {
+		$sitemap_opt = Helper::get_settings( "sitemap.{$sitemap}" );
+		if ( $sitemap_opt ) {
+			$sitemap_options[ "{$prefix}{$sitemap}" ] = "{$prefix}{$sitemap}";
+		}
+	}
+	if ( $sitemap_options ) {
+		Helper::update_all_settings( null, null, $sitemap_options );
+	}
+}
+
 cpseo_1_0_0_beta_4_convert_snippet_variables();
+cpseo_1_0_0_beta_4_add_settings_prefix();


### PR DESCRIPTION
Some infrequently used settings were missing the "cpseo_" prefix, a legacy of the fork from RM.

See #80 