### PR TITLE
Fix for misaligned Classic SEO icon

### DIFF
--- a/includes/admin/class-admin-bar-menu.php
+++ b/includes/admin/class-admin-bar-menu.php
@@ -17,6 +17,7 @@ use Classic_SEO\Traits\Hooker;
 use Classic_SEO\Helpers\Arr;
 use Classic_SEO\Helpers\Url;
 use Classic_SEO\Helpers\Param;
+use Classic_SEO\Admin\Admin_Helper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -140,7 +141,7 @@ class Admin_Bar_Menu {
 
 		$this->items['main'] = [
 			'id'       => self::MENU_IDENTIFIER,
-			'title'    => '<span class="cpseo-icon">' . $this->get_icon() . '</span><span class="cpseo-text">' . esc_html( 'Classic SEO', 'cpseo' ) . '</span>',
+			'title'    => '<span class="cpseo-icon">' . Admin_Helper::get_icon() . '</span><span class="cpseo-text">' . esc_html( 'Classic SEO', 'cpseo' ) . '</span>',
 			'href'     => Helper::get_admin_url( $first_menu ),
 			'meta'     => [ 'title' => esc_html__( 'Classic SEO Dashboard', 'cpseo' ) ],
 			'priority' => 10,
@@ -440,14 +441,4 @@ class Admin_Bar_Menu {
 		return $item1['priority'] < $item2['priority'] ? -1 : 1;
 	}
 
-	/**
-	 * Get Classic SEO icon.
-	 *
-	 * @param integer $width Width of the icon.
-	 *
-	 * @return string
-	 */
-	private function get_icon( $width = 18 ) {
-		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 394.47 392.43" width="' . $width . '" fill="#fff" stroke="#777" stroke-miterlimit="10" stroke-width=".25"><path d="M103.5 217.52c32-30 67.72-66.65 91.56-141.08L164.6 57.7 267.6.2 273.24 123l-30.1-18C138.27 267.15 21.82 284.44.42 256.62l.92.44c35.3 16.64 82.26-20.85 102.15-39.54z" stroke-opacity=".7" fill-rule="evenodd"/><path d="M27.35 321.77h63.12v70.54H27.35zm102-44.23h66.24V392.3h-66.24zm101.7-66.92h65.12v181.7h-65.12zM331.6 76.3h62.74v316H331.6z" stroke-opacity=".7"/></svg>';
-	}
 }

--- a/includes/admin/class-admin-helper.php
+++ b/includes/admin/class-admin-helper.php
@@ -32,6 +32,17 @@ class Admin_Helper {
 	public static function get_tooltip( $message ) {
 		return '<span class="cpseo-tooltip"><em class="dashicons-before dashicons-editor-help"></em><span>' . $message . '</span></span>';
 	}
+	
+	/**
+	 * Get Classic SEO icon.
+	 *
+	 * @param integer $width Width of the icon.
+	 *
+	 * @return string
+	 */
+	public static function get_icon( $width = 18 ) {
+		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 394.47 392.43" width="' . $width . '" fill="#9ea3a8" stroke="#777" stroke-miterlimit="10" stroke-width=".25"><path d="M103.5 217.52c32-30 67.72-66.65 91.56-141.08L164.6 57.7 267.6.2 273.24 123l-30.1-18C138.27 267.15 21.82 284.44.42 256.62l.92.44c35.3 16.64 82.26-20.85 102.15-39.54z" stroke-opacity=".7" fill-rule="evenodd"/><path d="M27.35 321.77h63.12v70.54H27.35zm102-44.23h66.24V392.3h-66.24zm101.7-66.92h65.12v181.7h-65.12zM331.6 76.3h62.74v316H331.6z" stroke-opacity=".7"/></svg>';
+	}
 
 	/**
 	 * Get admin view file.

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -14,6 +14,7 @@ use Classic_SEO\Runner;
 use Classic_SEO\Traits\Hooker;
 use Classic_SEO\Admin\Page;
 use Classic_SEO\Admin\Param;
+use Classic_SEO\Admin_Bar_Menu;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -40,6 +41,8 @@ class Admin_Menu implements Runner {
 	 */
 	public function register_pages() {
 
+		$cpseo_icon = base64_encode( Admin_Helper::get_icon() );
+
 		// Dashboard / Welcome / About.
 		new Page(
 			'cpseo',
@@ -47,7 +50,7 @@ class Admin_Menu implements Runner {
 			[
 				'position'   => 80,
 				'capability' => 'manage_options',
-				'icon'       => CPSEO_PLUGIN_URL . 'assets/admin/img/classic-seo-dashicon-white-on-transparent.svg',
+				'icon'       => 'data:image/svg+xml;base64,' . $cpseo_icon,
 				'render'     => Admin_Helper::get_view( 'dashboard' ),
 				'classes'    => [ 'cpseo-page' ],
 				'assets'     => [
@@ -106,9 +109,8 @@ class Admin_Menu implements Runner {
 		?>
 		<style>
 			#wp-admin-bar-cpseo .cpseo-icon {display: inline-block;top:2px;position: relative;padding:4px 0;margin-right:8px;line-height:20px;}
-			#wp-admin-bar-cpseo .cpseo-icon svg {fill-rule: evenodd;fill: rgba(240,245,250,.7);max-height:16px;}
+			#wp-admin-bar-cpseo .cpseo-icon svg {fill-rule: evenodd;fill: rgba(240,245,250,.6);max-height:16px;}
 			#wp-admin-bar-cpseo:hover .cpseo-icon svg {fill-rule: evenodd;fill: #00b9eb;}
-			#adminmenu #toplevel_page_cpseo .wp-menu-image img{max-width:20px;height:20px;-o-object-fit:fill;object-fit:fill;margin-top:-3px;width:20px}
 		</style>
 		<?php
 	}

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -105,21 +105,10 @@ class Admin_Menu implements Runner {
 	public function icon_css() {
 		?>
 		<style>
-			#wp-admin-bar-cpseo .cpseo-icon {
-				display: inline-block;
-				top: 6px;
-				position: relative;
-				padding-right: 10px;
-				max-width: 20px;
-			}
-			#wp-admin-bar-cpseo .cpseo-icon svg {
-				fill-rule: evenodd;
-				fill: #dedede;
-			}
-			#wp-admin-bar-cpseo:hover .cpseo-icon svg {
-				fill-rule: evenodd;
-				fill: #00b9eb;
-			}
+			#wp-admin-bar-cpseo .cpseo-icon {display: inline-block;top:2px;position: relative;padding:4px 0;margin-right:8px;line-height:20px;}
+			#wp-admin-bar-cpseo .cpseo-icon svg {fill-rule: evenodd;fill: rgba(240,245,250,.7);max-height:16px;}
+			#wp-admin-bar-cpseo:hover .cpseo-icon svg {fill-rule: evenodd;fill: #00b9eb;}
+			#adminmenu #toplevel_page_cpseo .wp-menu-image img{max-width:20px;height:20px;-o-object-fit:fill;object-fit:fill;margin-top:-3px;width:20px}
 		</style>
 		<?php
 	}


### PR DESCRIPTION
Resolves the misaligned icon in the top admin bar and side menu.

![image](https://user-images.githubusercontent.com/4199514/88464951-a96bb780-ceb6-11ea-81fd-5f00d8b93ac8.png)
