### PR TITLE
Clean up .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Exclude the following when creating zip archive (git archive)
+.gitignore export-ignore
+.gitattributes export-ignore
+sitemap-cache/* export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,2 @@
-*.bat
-*.sh
-*.bak
 *.zip
-*.7z
-assets/admin/js/src/*
-assets/admin/js/orig/*
 sitemap-cache/*
-composer.*


### PR DESCRIPTION
The `.gitignore` file should only contain entries for files that routinely appear during development/usage but that should not be committed back to the repository.

The `composer.json` and `composer.lock` files definitely should not be ignored, they should be committed and managed along with the rest of the repository so that versions of all dependencies are reproducible by others: https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control

`*.bat` and `*.sh` are more debatable but I would argue that if there are scripts used to manipulate the project then they should also be committed to the repository. If you have some scripts you are keeping to yourself then you can store them outside of your repository or exclude them using `.git/info/exclude`.

If you or your editor are creating `*.bak` files then you should add these to a **global** `.gitignore` file.

I'm not sure what `assets/admin/js/src/*` and `assets/admin/js/orig/*` contain but I don't see anything here so these entries in `.gitignore` seem unnecessary.