### PR TITLE
Excludes .gitignore and .gitattributes from git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Exclude the following when creating zip archive (git archive)
+.gitignore export-ignore
+.gitattributes export-ignore
+sitemap-cache/* export-ignore


### PR DESCRIPTION
Intended for use with `git archive`. For example:

`git archive --prefix=classicpress-seo/ -o "classicpress-seo.zip" HEAD`

This will prevent `.gitignore` and `.gitattributes` as well as the `sitemap-cache` folder from being included in the zip file when the above command is used.