### PR TITLE
Fix Search Console stats query syntax

### DIFF
--- a/includes/modules/search-console/class-db.php
+++ b/includes/modules/search-console/class-db.php
@@ -333,9 +333,22 @@ class DB {
 			return $data;
 		}
 
-		$days = $wpdb->get_var( 'SELECT COUNT(DISTINCT DATE(date)) as days FROM ' . $wpdb->prefix . 'cpseo_sc_analytics' ); // phpcs:ignore
-		$rows = $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $wpdb->prefix . 'cpseo_sc_analytics' ); // phpcs:ignore
-		$size = $wpdb->get_var( 'SELECT SUM((data_length + index_length)) AS size FROM information_schema.TABLES WHERE table_schema="' . $wpdb->dbname . '" AND (table_name="' . $wpdb->prefix . 'cpseo_sc_analytics")' ); // phpcs:ignore
+		$days = $wpdb->get_var(
+			"SELECT COUNT(DISTINCT DATE(date)) as days
+			FROM {$wpdb->prefix}cpseo_sc_analytics"
+		);
+		$rows = $wpdb->get_var(
+			"SELECT COUNT(*)
+			FROM {$wpdb->prefix}cpseo_sc_analytics"
+		);
+		$size = $wpdb->get_var( $wpdb->prepare(
+			"SELECT SUM(data_length + index_length) AS size
+			FROM information_schema.TABLES
+			WHERE table_schema = '%s'
+			AND table_name = '%s'",
+			$wpdb->dbname,
+			$wpdb->prefix . 'cpseo_sc_analytics'
+		) );
 
 		$data = compact( 'days', 'rows', 'size' );
 


### PR DESCRIPTION
This PR fixes #87 (database error upon plugin activation, or approximately once per day when a transient related to the Search Console functionality is re-calculated):

> ![2020-07-24T15-06-28Z](https://user-images.githubusercontent.com/227022/88405989-8dd1b580-cdbf-11ea-9620-c98d6718c7c5.png)

The problem, as explained in #87 is that this query uses double quotes for a string value which is incompatible with the `ANSI_QUOTES` MySQL mode. Since this mode is not otherwise problematic for ClassicPress this is best fixed in the plugin code.

I also added `$wpdb->prepare` to the query that uses a (somewhat) dynamic `WHERE` clause as a best practice.