### PR TITLE
Fix a PHP notice in Conditional::is_rest()

### DIFF
--- a/includes/helpers/class-conditional.php
+++ b/includes/helpers/class-conditional.php
@@ -97,7 +97,11 @@ trait Conditional {
 		$rest_url    = wp_parse_url( trailingslashit( rest_url() ) );
 		$current_url = wp_parse_url( add_query_arg( [] ) );
 
-		return 0 === strpos( $current_url['path'], $rest_url['path'], 0 );
+		return (
+			isset( $current_url['path'] ) &&
+			isset( $rest_url['path'] ) &&
+			0 === strpos( $current_url['path'], $rest_url['path'], 0 )
+		);
 	}
 	
 	


### PR DESCRIPTION
When you get a request to `//xmlrpc.php` with a double slash (someone's "hacking" script is misbehaving), this causes a PHP notice in Classic SEO which may show up in the error logs depending on the PHP settings:

>PHP Notice:  Undefined index: path in wp-content/plugins/classicpress-seo/includes/helpers/class-conditional.php on line 100

This is because parsing such a URL using `wp_parse_url()` returns `['host' => 'xmlrpc.php']` (no `path` key as expected by the code below that).

There are bigger problems here - parsing a request path as a full URL is wrong - but this PR is the easiest way to get rid of the notice.