### PR TITLE
Removes extraneous '%s' placeholder on Search Console settings page

### DIFF
--- a/includes/modules/search-console/class-search-console.php
+++ b/includes/modules/search-console/class-search-console.php
@@ -205,7 +205,7 @@ class Search_Console extends Base {
 				'search-console' => [
 					'icon'  => 'fa fa-search-plus',
 					'title' => esc_html__( 'Search Console', 'cpseo' ),
-					'desc'  => esc_html__( 'Connect to Google Search Console profile to see the most important information from Google. %s.', 'cpseo' ),
+					'desc'  => esc_html__( 'Connect to Google Search Console profile to see the most important information from Google.', 'cpseo' ),
 					'file'  => $this->directory . '/views/options.php',
 				],
 			],


### PR DESCRIPTION
Removes the '%s' in the following view of the Search Console settings page :

![placeholder](https://user-images.githubusercontent.com/4199514/89124195-0970e800-d4cd-11ea-8f63-617a0b7a988a.jpg)
