### PR TITLE
Fixes PHP Notice in class-admin-bar-menu.php

### DIFF
--- a/includes/admin/class-admin-bar-menu.php
+++ b/includes/admin/class-admin-bar-menu.php
@@ -218,7 +218,11 @@ class Admin_Bar_Menu {
 	 * Add taxonomy menu
 	 */
 	private function add_taxonomy_menu() {
-		$term   = get_queried_object();
+		$term = get_queried_object();
+		if ( empty( $term ) ) {
+			return;
+		}
+
 		$labels = get_taxonomy_labels( get_taxonomy( $term->taxonomy ) );
 		$this->add_sub_menu(
 			'tax',


### PR DESCRIPTION
Fixes the following error that was occasionally being thrown:

Trying to get property 'taxonomy' of non-object in `wp-content/plugins/classicpress-seo/includes/admin/class-admin-bar-menu.php`.