### PR TITLE
Change WC references to CC, or remove completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Local SEO / Knowledge Graph|Support for BuddyPress
 Redirections|Webmaster tools
 Rich Snippets|SEO Analysis
 XML Sitemap|Ability to edit .htaccess
-Support for [Classic Commerce](https://github.com/ClassicPress-plugins/classic-commerce) and WooCommerce|Ability to edit robots.txt
+Support for [Classic Commerce](https://github.com/ClassicPress-plugins/classic-commerce)|Ability to edit robots.txt
 Social meta: Facebook, Twitter, Google Places, LinkedIn, Instagram, YouTube, Pinterest|Social meta: Yelp, FourSquare, Flickr, Reddit, SoundCloud, Tumblr and Myspace
 Imports for Rank Math, Yoast, All In One SEO and The SEO Framework | Imports for AIO Rich Snippets, SEOPress, WP Schema Pro, Redirection
 Role Manager|

--- a/includes/modules/rich-snippet/views/metabox-options.php
+++ b/includes/modules/rich-snippet/views/metabox-options.php
@@ -22,7 +22,7 @@ if ( ( class_exists( 'WooCommerce' ) && 'product' === $post_type ) || ( class_ex
 		'id'      => 'cpseo_woocommerce_notice',
 		'type'    => 'notice',
 		'what'    => 'info',
-		'content' => esc_html__( 'Classic SEO automatically inserts additional Rich Snippet meta data for WooCommerce products. You can set the Rich Snippet Type to "None" to disable this feature and just use the default data added by WooCommerce.', 'cpseo' ),
+		'content' => esc_html__( 'Classic SEO automatically inserts additional Rich Snippet meta data for Classic Commerce products. You can set the Rich Snippet Type to "None" to disable this feature and just use the default data added by Classic Commerce.', 'cpseo' ),
 	]);
 
 	$cmb->add_field([

--- a/includes/modules/woocommerce/class-admin.php
+++ b/includes/modules/woocommerce/class-admin.php
@@ -36,7 +36,7 @@ class Admin extends Base {
 				'id'        => 'woocommerce',
 				'directory' => $directory,
 				'help'      => [
-					'title' => esc_html__( 'WooCommerce', 'cpseo' ),
+					'title' => esc_html__( 'Classic Commerce', 'cpseo' ),
 					'view'  => $directory . '/views/help.php',
 				],
 			]
@@ -75,8 +75,8 @@ class Admin extends Base {
 			[
 				'woocommerce' => [
 					'icon'  => 'dashicons dashicons-cart',
-					'title' => esc_html__( 'WooCommerce', 'cpseo' ),
-					'desc'  => esc_html__( 'Choose how you want Classic SEO to handle your WooCommerce SEO. These options help you create cleaner, SEO friendly URLs, and optimize your WooCommerce product pages.', 'cpseo' ),
+					'title' => esc_html__( 'Classic Commerce', 'cpseo' ),
+					'desc'  => esc_html__( 'Choose how you want Classic SEO to handle your Classic Commerce SEO. These options help you create cleaner, SEO friendly URLs, and optimize your Classic Commerce product pages.', 'cpseo' ),
 					'file'  => $this->directory . '/views/options-general.php',
 				],
 			],

--- a/includes/modules/woocommerce/views/help.php
+++ b/includes/modules/woocommerce/views/help.php
@@ -9,13 +9,13 @@
 use Classic_SEO\Helper;
 ?>
 
-<h3><?php esc_html_e( 'WooCommerce and Classic Commerce', 'cpseo' ); ?></h3>
+<h3><?php esc_html_e( 'Classic Commerce', 'cpseo' ); ?></h3>
 
-<p><?php esc_html_e( 'SEO is an important part of any website and that\'s especially true for a WooCommerce or Classic Commerce store.', 'cpseo' ); ?></p>
+<p><?php esc_html_e( 'SEO is an important part of any website and that\'s especially true for a Classic Commerce store.', 'cpseo' ); ?></p>
 
-<p><?php esc_html_e( 'With the Classic SEO plugin, you can easily optimize your WooCommerce or Classic Commerce store in general and product pages in particular.', 'cpseo' ); ?></p>
+<p><?php esc_html_e( 'With the Classic SEO plugin, you can easily optimize your Classic Commerce store in general, and product pages in particular.', 'cpseo' ); ?></p>
 
-<p><strong><?php esc_html_e( 'Optimizing Your WooCommerce or Classic Commerce Store', 'cpseo' ); ?></strong></p>
+<p><strong><?php esc_html_e( 'Optimizing Your Classic Commerce Store', 'cpseo' ); ?></strong></p>
 
 <p>
 	<?php

--- a/includes/modules/woocommerce/views/help.php
+++ b/includes/modules/woocommerce/views/help.php
@@ -57,7 +57,7 @@ use Classic_SEO\Helper;
 	<?php
 	printf(
 		/* translators: link to local seo settings */
-		__( 'To access those options, head over to <a href="%1$s">ClassicPress Dashboard > Classic SEO > General Settings > WooCommerce</a>.', 'cpseo' ),
+		__( 'To access those options, head over to <a href="%1$s">ClassicPress Dashboard > Classic SEO > General Settings > Classic Commerce</a>.', 'cpseo' ),
 		Helper::get_admin_url( 'options-general#setting-panel-woocommerce' )
 	);
 	?>

--- a/includes/modules/woocommerce/views/options-general.php
+++ b/includes/modules/woocommerce/views/options-general.php
@@ -39,7 +39,7 @@ $cmb->add_field([
 	'id'      => 'cpseo_wc_remove_generator',
 	'type'    => 'switch',
 	'name'    => esc_html__( 'Remove Generator Tag', 'cpseo' ),
-	'desc'    => esc_html__( 'Remove WooCommerce generator tag from the source code.', 'cpseo' ),
+	'desc'    => esc_html__( 'Remove Classic Commerce generator tag from the source code.', 'cpseo' ),
 	'default' => 'on',
 ]);
 
@@ -47,7 +47,7 @@ $cmb->add_field([
 	'id'      => 'cpseo_remove_shop_snippet_data',
 	'type'    => 'switch',
 	'name'    => esc_html__( 'Remove Snippet Data', 'cpseo' ),
-	'desc'    => esc_html__( 'Remove Snippet Data from WooCommerce Shop page.', 'cpseo' ),
+	'desc'    => esc_html__( 'Remove Snippet Data from Classic Commerce Shop page.', 'cpseo' ),
 	'default' => 'on',
 ]);
 

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,6 @@ Classic SEO is the first SEO plugin built specifically to work with ClassicPress
 * **404 Monitor**
 * **Support for ACF**
 * **Support for Classic Commerce**
-* **Support for WooCommerce**
 * **Internal Linking Suggestions**
 * **Role Manager**
 * **Importers for Rank Math, Yoast, All In One SEO and The SEO Framework**


### PR DESCRIPTION
This PR changes the remaining mentions of WooCommerce to Classic Commerce, primarily in the files in the modules > woocommerce folder. 

It also removes references to WooCommerce in the help section where both WC and CC were mentioned together.

Statements of support for WC have been removed from readme.txt and README.md.

NOTE: There are still some references to WooCommerce in code comments that could be removed later. All WC namespaces etc are intact. 

Fixes Issue #111