### PR TITLE
Remove Google structured data link

### DIFF
--- a/includes/admin/class-admin-bar-menu.php
+++ b/includes/admin/class-admin-bar-menu.php
@@ -339,12 +339,6 @@ class Admin_Bar_Menu {
 
 		$url   = urlencode( Url::get_current_url() );
 		$items = [
-			'google-structured-data'     => [
-				'title' => esc_html__( 'Google Structured Data', 'cpseo' ),
-				'href'  => 'https://search.google.com/structured-data/testing-tool/?url=' . $url,
-				'meta'  => [ 'title' => esc_html__( 'Google Structured Data Testing Tool', 'cpseo' ) ],
-			],
-
 			'google-pagespeed'           => [
 				'title' => esc_html__( 'Google PageSpeed', 'cpseo' ),
 				'href'  => 'https://developers.google.com/speed/pagespeed/insights/?url=' . $url,


### PR DESCRIPTION
See issue #115 - Google Structured Data is being deprecated.

This Google test will soon be deprecated and the menu item is not required. The Rich Results Test is now the preferred option and that link is already available on the menu.

The revised file has been tested.