### PR TITLE
Remove remaining traces of site analysis feature

### DIFF
--- a/includes/helpers/class-wordpress.php
+++ b/includes/helpers/class-wordpress.php
@@ -289,7 +289,6 @@ trait WordPress {
 			'cpseo_link_builder'    => esc_html__( 'Link Builder', 'cpseo' ),
 			'cpseo_redirections'    => esc_html__( 'Redirections', 'cpseo' ),
 			'cpseo_role_manager'    => esc_html__( 'Role Manager', 'cpseo' ),
-			'cpseo_site_analysis'   => esc_html__( 'Site-Wide Analysis', 'cpseo' ),
 			'cpseo_onpage_analysis' => esc_html__( 'On-Page Analysis', 'cpseo' ),
 			'cpseo_onpage_general'  => esc_html__( 'On-Page General Settings', 'cpseo' ),
 			'cpseo_onpage_advanced' => esc_html__( 'On-Page Advanced Settings', 'cpseo' ),

--- a/includes/modules/role-manager/class-capability-manager.php
+++ b/includes/modules/role-manager/class-capability-manager.php
@@ -63,7 +63,6 @@ class Capability_Manager {
 		$this->register( 'cpseo_link_builder', esc_html__( 'Link Builder', 'cpseo' ) );
 		$this->register( 'cpseo_redirections', esc_html__( 'Redirections', 'cpseo' ) );
 		$this->register( 'cpseo_role_manager', esc_html__( 'Role Manager', 'cpseo' ) );
-		$this->register( 'cpseo_site_analysis', esc_html__( 'Site-Wide Analysis', 'cpseo' ) );
 		$this->register( 'cpseo_onpage_analysis', esc_html__( 'On-Page Analysis', 'cpseo' ) );
 		$this->register( 'cpseo_onpage_general', esc_html__( 'On-Page General Settings', 'cpseo' ) );
 		$this->register( 'cpseo_onpage_advanced', esc_html__( 'On-Page Advanced Settings', 'cpseo' ) );
@@ -147,7 +146,6 @@ class Capability_Manager {
 
 		if ( 'editor' === $role ) {
 			return [
-				'cpseo_site_analysis',
 				'cpseo_onpage_analysis',
 				'cpseo_onpage_general',
 				'cpseo_onpage_snippet',


### PR DESCRIPTION
The site analysis feature has never been included in CPSEO but there were a few remnants of code left behind. This PR hopefully removes the last traces.