### PR TITLE
Remove references to cpseo_sc_analytics database table

### DIFF
--- a/classicpress-seo.php
+++ b/classicpress-seo.php
@@ -40,7 +40,7 @@ class Classic_SEO {
 	 *
 	 * @var string
 	 */
-	public $db_version = '1';
+	public $db_version = '2';
 
 	/**
 	 * Minimum version of ClassicPress required to run Classic SEO.

--- a/includes/class-installer.php
+++ b/includes/class-installer.php
@@ -96,7 +96,6 @@ class Installer {
 		$tables[] = $wpdb->prefix . 'cpseo_redirections_cache';
 		$tables[] = $wpdb->prefix . 'cpseo_internal_links';
 		$tables[] = $wpdb->prefix . 'cpseo_internal_meta';
-		$tables[] = $wpdb->prefix . 'cpseo_sc_analytics';
 
 		return $tables;
 	}

--- a/includes/class-updates.php
+++ b/includes/class-updates.php
@@ -27,7 +27,7 @@ class Updates implements Runner {
 	 * @var array
 	 */
 	private static $updates = [
-		'1.1.0'        => 'updates/update-1.1.0.php',
+		'2.0.0'        => 'updates/update-2.0.0.php',
 	];
 	
 	/**

--- a/includes/modules/status/class-system-status.php
+++ b/includes/modules/status/class-system-status.php
@@ -93,7 +93,6 @@ class System_Status {
 			'cpseo_redirections_cache',
 			'cpseo_internal_links',
 			'cpseo_internal_meta',
-			'cpseo_sc_analytics',
 		];
 
 		$core_tables    = array_map( [ $this, 'add_db_table_prefix' ], $core_tables );

--- a/includes/updates/update-2.0.0.php
+++ b/includes/updates/update-2.0.0.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * The Updates routine for version 2_0_0
+ * The Updates routine for version 2.0.0
  *
- * @since      2_0_0
+ * @since      2.0.0
  * @package    Classic_SEO
  * @subpackage Classic_SEO\Updates
  */
@@ -15,6 +15,7 @@ use Classic_SEO\Admin\Admin_Helper;
 
 /**
  * Remove table cpseo_sc_analytics as it is no longer used
+ * Google search console feature removed in 2.0.0
  */
 function cpseo_2_0_0_remove_gsc_table() {
 	global $wpdb;
@@ -27,6 +28,7 @@ function cpseo_2_0_0_remove_gsc_table() {
 	delete_option( 'cpseo_search_console_data' );
 }
 cpseo_2_0_0_remove_gsc_table();
+
 
 /*
  * 	Clear cpseo_search_console_get_analytics cron job.

--- a/includes/updates/update-2_0_0.php
+++ b/includes/updates/update-2_0_0.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * The Updates routine for version 1.1.0
+ * The Updates routine for version 2_0_0
  *
- * @since      1.1.0
+ * @since      2_0_0
  * @package    Classic_SEO
  * @subpackage Classic_SEO\Updates
  */
@@ -16,7 +16,7 @@ use Classic_SEO\Admin\Admin_Helper;
 /**
  * Remove table cpseo_sc_analytics as it is no longer used
  */
-function cpseo_1_1_0_remove_gsc_table() {
+function cpseo_2_0_0_remove_gsc_table() {
 	global $wpdb;
 	require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 
@@ -26,12 +26,12 @@ function cpseo_1_1_0_remove_gsc_table() {
 
 	delete_option( 'cpseo_search_console_data' );
 }
-cpseo_1_1_0_remove_gsc_table();
+cpseo_2_0_0_remove_gsc_table();
 
 /*
  * 	Clear cpseo_search_console_get_analytics cron job.
  */
-function cpseo_1_1_0_remove_gsc_scheduled_hook() {	
+function cpseo_2_0_0_remove_gsc_scheduled_hook() {	
 	wp_clear_scheduled_hook( 'cpseo_search_console_get_analytics' );
 }
-cpseo_1_1_0_remove_gsc_scheduled_hook()
+cpseo_2_0_0_remove_gsc_scheduled_hook()

--- a/uninstall.php
+++ b/uninstall.php
@@ -65,7 +65,6 @@ function cpseo_remove_data() {
 	cpseo_drop_table( 'cpseo_redirections_cache' );
 	cpseo_drop_table( 'cpseo_internal_links' );
 	cpseo_drop_table( 'cpseo_internal_meta' );
-	cpseo_drop_table( 'cpseo_sc_analytics' );
 
 	// Remove Capabilities.
 	/**


### PR DESCRIPTION
Removes `cpseo_sc_analytics` table from database, installer and uninstaller.

Bumps db version to 2