### PR TITLE
Remove link to placeholder in social preview

### DIFF
--- a/includes/metaboxes/social-preview.php
+++ b/includes/metaboxes/social-preview.php
@@ -12,7 +12,7 @@ use Classic_SEO\Helpers\Param;
 
 global $post;
 
-$thumbnail = has_post_thumbnail() ? absint( get_post_thumbnail_id() ) : '//via.placeholder.com/526x292?text=Social+Preview+Image';
+$thumbnail = has_post_thumbnail() ? absint( get_post_thumbnail_id() ) : '';
 
 // Facebook Image.
 $fb_thumbnail = '';


### PR DESCRIPTION
Removes unnecessary placeholder[.]com image in social media preview. 

Removing it will potentially reduce the number of external calls.