### PR TITLE
Fix for ajax error when dismissing some CPSEO notices

### DIFF
--- a/includes/helpers/class-notification-center.php
+++ b/includes/helpers/class-notification-center.php
@@ -113,7 +113,7 @@ class Notification_Center {
 		?>
 		<script>
 			;(function($) {
-				$( '.is-dismissible' ).on( 'click', '.notice-dismiss', function() {
+				$( '.is-dismissible cpseo_notice' ).on( 'click', '.notice-dismiss', function() {
 					var notice = $( this ).parent()
 					$.ajax({
 						url: ajaxurl,

--- a/includes/helpers/class-notification.php
+++ b/includes/helpers/class-notification.php
@@ -155,7 +155,7 @@ class Notification {
 	}
 
 	/**
-	 * Dismiss persisten notification.
+	 * Dismiss persistent notification.
 	 *
 	 * @codeCoverageIgnore
 	 */
@@ -191,6 +191,7 @@ class Notification {
 		// Default notification classes.
 		$classes = [
 			'notice',
+			'cpseo_notice',
 			'notice-' . $this->args( 'type' ),
 			$this->args( 'classes' ),
 		];


### PR DESCRIPTION
Some admin notices created by CPSEO generated an ajax error when they are dismissed. In testing, this seems to be limited to notifications such as "Settings updated".

This fix prevents that error.

Props @xxsimoxx 

Closes #143 